### PR TITLE
add functionality to Makefile to build static+shared library versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # Set LIBUV to system to use the version deployed in the system
 # Set LIBUV to pkgconfig to use pkg-config for the setup
 #
-LIBUV=deps/libuv
+#LIBUV=deps/libuv
 #LIBUV=system
-#LIBUV=pkg-config
+LIBUV=pkg-config
 
 CC=cc
 
@@ -13,7 +13,6 @@ CC=cc
 # Define buildtype : shared or static
 #
 BUILDTYPE=static
-
 
 # Make sure to `make distclean` before building when changing CC.
 # Default build is debug mode.
@@ -77,9 +76,9 @@ ifeq ($(BUILDTYPE), shared)
 else
    UVT=target/libuv.a
 endif
-ifeq ($(LIBUV), pkgconfig)
-   CFLAGS+=$(pkg-config --cflags libuv)
-   LDFLAGS+=$(pkg-config --libs libuv)
+ifeq ($(LIBUV), pkg-config)
+   CFLAGS+=$(shell pkg-config --cflags libuv)
+   LDFLAGS+=$(shell pkg-config --libs libuv)
 else ifneq ($(LIBUV), system)
    CFLAGS+=-I./deps/libuv/include
    UVTARGET=$(UVT)

--- a/src/duv/duv.h
+++ b/src/duv/duv.h
@@ -1,7 +1,7 @@
 #ifndef DUV_H
 #define DUV_H
 
-#include "../../deps/libuv/include/uv.h"
+#include <uv.h>
 #include "../../deps/duktape-releases/src/duktape.h"
 
 #ifndef PATH_MAX


### PR DESCRIPTION
To use the seaduk version in external products it is needed, that core functions are build as libraries. The patched Makefile can now (depending on flags)
- create libduv.a (static build)
- create libduv.so, libseaduk.so (shared build)
- build nucleus as a static or shared build
- install target for binaries + libraries + headers (for external projects)
- init-duktape, init-libuv make targets for git submodule initialization
- use libuv from git submodule, deployed by the system or pkg-config

To control the buildprocess you can set in the Makefile :

LIBUV=deps/libuv (default)
# LIBUV=system
# LIBUV=pkg-config

BUILDTYPE=static (default)
# BUILDTYPE=shared

Tested on Redhat EL7 (gcc), Darwin (clang)
