### PR TITLE
Accept buffer objects in addition to plain buffers

### DIFF
--- a/src/duv/dschema.c
+++ b/src/duv/dschema.c
@@ -1,7 +1,11 @@
 #include "dschema.h"
 
 duk_bool_t dschema_is_data(duk_context* ctx, duk_idx_t index) {
+#if (DUK_VERSION >= 10700)
+  return duk_is_string(ctx, index) || duk_is_buffer_data(ctx, index);
+#else
   return duk_is_string(ctx, index) || duk_is_buffer(ctx, index);
+#endif
 }
 
 duk_bool_t dschema_is_fd(duk_context* ctx, duk_idx_t index) {

--- a/src/duv/utils.c
+++ b/src/duv/utils.c
@@ -274,6 +274,10 @@ void duv_get_data(duk_context *ctx, int index, uv_buf_t *buf) {
     buf->base = (char*) duk_get_lstring(ctx, index, &buf->len);
   }
   else {
+#if (DUK_VERSION >= 10700)
+    buf->base = duk_get_buffer_data(ctx, index, &buf->len);
+#else
     buf->base = duk_get_buffer(ctx, index, &buf->len);
+#endif
   }
 }


### PR DESCRIPTION
This is still a work in progress so don't merge yet!

Extend the script->C buffer data validation so that buffer objects are accepted in addition to plain buffers. This allows application code to create buffer data using e.g. `new Uint8Array(256)` and then write it to a native binding like a socket. To validate buffer objects reliably (handling a zero-size fixed buffer correctly), `duk_is_buffer_data()` is needed from Duktape master or eventual Duktape 1.7.0 maintenance release: https://github.com/svaarala/duktape/pull/1221.

Going forward it may be good to promote the use of standard buffer objects (e.g. Uint8Array) rather than Duktape custom types. In Duktape 2.x plain buffers behave like Uint8Arrays with some limitations like not having a property table so the current approach of using plain buffers for data buffer passing is relatively clean for scripts. However, it'd be nice to allow scripts to create buffers using e.g. `new Uint8Array(256)` and pass them into write() calls.

Longer term plan for Duktape is to simplify the buffer data model so that script and C code would see as standard objects as possible. The plain buffer type may be eliminated at some point, and effort made to ensure standard buffer objects have more memory optimized representations. This should simplify buffer handling overall. For now it's good to accept plain buffers and buffer objects wherever applicable.

There's no need to change how plain buffers are used for handles and such as far as I can see, at least for now.